### PR TITLE
fix adjacent html lists bug

### DIFF
--- a/src/lua/publisher.lua
+++ b/src/lua/publisher.lua
@@ -2368,6 +2368,7 @@ function parse_html( elt, parameter )
                 end
             end
             a:append(node.copy(marker))
+            a:append(paragraph:new())
             return a
         elseif eltname == "ol" then
             local counter = 0
@@ -2388,6 +2389,7 @@ function parse_html( elt, parameter )
                 end
             end
             a:append(node.copy(marker))
+            a:append(paragraph:new())
             return a
         elseif eltname == "a" then
             if elt.href == nil then


### PR DESCRIPTION
LuaTeX crashes with `! This can't happen (vpack).` if a paragraph contains two or more adjacent HTML lists without whitespace or another element between them.

This quick fix always appends a `paragraph:new()`. Not sure if this is the best way, but it basically behaves like a whitespace.

Example (HTML split in two values for readability, but doesn’t matter):
```
<Layout xmlns="urn:speedata.de:2009/publisher/en" xmlns:sd="urn:speedata:2009/publisher/functions/en">
  <Record element="data">
      <PlaceObject><Textblock><Paragraph><!-- works -->
          <Value select="sd:decode-html('&lt;ul&gt;&lt;li&gt;list&lt;/li&gt;&lt;/ul&gt; ')"/>
          <Value select="sd:decode-html('&lt;ul&gt;&lt;li&gt;list&lt;/li&gt;&lt;/ul&gt;')"/>
      </Paragraph></Textblock></PlaceObject>
      <PlaceObject><Textblock><Paragraph><!-- breaks -->
          <Value select="sd:decode-html('&lt;ul&gt;&lt;li&gt;list&lt;/li&gt;&lt;/ul&gt;')"/>
          <Value select="sd:decode-html('&lt;ul&gt;&lt;li&gt;list&lt;/li&gt;&lt;/ul&gt;')"/>
      </Paragraph></Textblock></PlaceObject>
  </Record>
</Layout>
```