### PR TITLE
fix adjacent html lists bug, now without extra vertical space

### DIFF
--- a/src/lua/publisher.lua
+++ b/src/lua/publisher.lua
@@ -2368,7 +2368,7 @@ function parse_html( elt, parameter )
                 end
             end
             a:append(node.copy(marker))
-            a:append(paragraph:new())
+            a:append(node.new(glue_node))
             return a
         elseif eltname == "ol" then
             local counter = 0
@@ -2389,7 +2389,7 @@ function parse_html( elt, parameter )
                 end
             end
             a:append(node.copy(marker))
-            a:append(paragraph:new())
+            a:append(node.new(glue_node))
             return a
         elseif eltname == "a" then
             if elt.href == nil then


### PR DESCRIPTION
See above. Works similar but doesn’t create a blank line.