### PR TITLE
fix HTML tables inside Output elements

### DIFF
--- a/src/lua/publisher/tabular.lua
+++ b/src/lua/publisher/tabular.lua
@@ -27,6 +27,8 @@ function new( self )
         columncolors  = {},
         -- The distance between column i and i+1, currently not used
         column_distances = {},
+        -- number of frames the table is split across, initialise to a sane default value
+        split = 1,
     }
 
     setmetatable(t, self)


### PR DESCRIPTION
HTML tables currently produce errors when placed inside Output/Text elements.

To reproduce:

```XML
<Layout
  xmlns="urn:speedata.de:2009/publisher/en"
  xmlns:sd="urn:speedata:2009/publisher/functions/en">
  <Record element="data">
    <Output>
        <Text>
            <Paragraph>
                <Value select="sd:decode-html('&lt;table&gt;&lt;tbody&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;lorem&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/tbody&gt;&lt;/table&gt;')"/>
            </Paragraph>
        </Text>
    </Output>
  </Record>
</Layout>
```