### PR TITLE
`<AttachFile>`: `name` extension from `filename`

### DIFF
--- a/src/lua/publisher/commands.lua
+++ b/src/lua/publisher/commands.lua
@@ -184,8 +184,12 @@ function commands.attachfile( layoutxml,dataxml )
     local filename = publisher.read_attribute(layoutxml,dataxml,"filename","string")
     local selection = publisher.read_attribute(layoutxml,dataxml,"select","xpathraw")
     local destfilename = publisher.read_attribute(layoutxml,dataxml,"name","string", "ZUGFeRD-invoice.xml")
+    local filename_extension = filename:match("^.*%.(.+)$"):lower()
     local zugferdcontents
     local modificationtime
+    if destfilename:match("^.*%.(.+)$") == nil then
+        destfilename = string.format("%s.%s",destfilename,filename_extension)
+    end
     if selection ~= nil then
         zugferdcontents = publisher.xml_to_string(selection[1],0)
         modificationtime = os.time()


### PR DESCRIPTION
if and only if `name` includes no extension
this is a way to avoid stupid mistakes