### PR TITLE
Fix config.go (replace "\r" from ver.Patch)

### DIFF
--- a/src/go/sphelper/config/config.go
+++ b/src/go/sphelper/config/config.go
@@ -81,7 +81,7 @@ func readVersion(product string, basedir string) Version {
 			if err != nil {
 				panic("Cannot parse minor number in version")
 			}
-			ver.Patch, err = strconv.Atoi(versionStrings[2])
+			ver.Patch, err = strconv.Atoi(strings.ReplaceAll(versionStrings[2], "\r", ""))
 			if err != nil {
 				panic("Cannot parse patch number in version")
 			}


### PR DESCRIPTION
On windows I was getting this error:

strconv.Atoi: parsing "11\r": invalid syntax
panic: Cannot parse patch number in version

Removing the "\r" from versionStrings[2] fixes this.